### PR TITLE
:bug: fix: fix lint error

### DIFF
--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -1,6 +1,5 @@
 import { ThemeConfig } from 'antd';
-import { MappingAlgorithm } from 'antd/es/config-provider/context';
-import { AliasToken } from 'antd/es/theme/interface';
+import { AliasToken, MappingAlgorithm } from 'antd/es/theme/interface';
 
 import { BrowserPrefers, ThemeAppearance, ThemeMode } from './appearance';
 


### PR DESCRIPTION
ant design 5.8.0把config-provider/context里的MappingAlgorithm去掉了
见PR: https://github.com/ant-design/ant-design/pull/43810/files

close #89 
