### PR TITLE
:bug: fix: fix types due to father build error

### DIFF
--- a/src/factories/createThemeProvider/index.tsx
+++ b/src/factories/createThemeProvider/index.tsx
@@ -1,7 +1,7 @@
-import { Context, memo, ReactNode, useContext } from 'react';
+import { Context, FC, memo, useContext } from 'react';
 
 import { DEFAULT_THEME_CONTEXT, DEFAULT_THEME_PROVIDER } from '@/functions/setupStyled';
-import { StyledConfig, StyleEngine, UseTheme } from '@/types';
+import { StyleEngine, StyledConfig, UseTheme } from '@/types';
 
 import { createStyledThemeProvider } from '@/factories/createStyledThemeProvider';
 import AntdProvider from './AntdProvider';
@@ -35,7 +35,7 @@ interface CreateThemeProviderOptions {
 }
 export const createThemeProvider = (
   option: CreateThemeProviderOptions,
-): (<T = any, S = any>(props: ThemeProviderProps<T, S>) => ReactNode) => {
+): (<T = any, S = any>(props: ThemeProviderProps<T, S>) => ReturnType<FC>) => {
   // 如果有全局配置 styledConfig，那么 ThemeProvider
   const DefaultStyledThemeProvider = option.styledConfig
     ? createStyledThemeProvider(option.styledConfig)


### PR DESCRIPTION
## 背景
![image](https://github.com/ant-design/antd-style/assets/28616219/5f4167f1-583d-4d33-829d-23e7d5eb3562)

`@types/react` 最新([18.2.x](https://unpkg.com/browse/@types/react@18.2.21/index.d.ts))的返回是 ReactNode ，而之前的老版本则是返回的 `ReactElement`。当使用 IDE 版本为 `ts <=5.0` 时， FC 使用的类型是 ts5.0 文件夹下的 `index.d.ts` ，一定会走到老版本。

而 father 4.3.4 的版本加入了相应的强校验，且依赖的 ts 版本为 `5.0.4` ，导致react 声明无法匹配，构建会报错。

## 解决方案

将类型从 `ReactNode` 改为 `ReturnType<FC>`