### PR TITLE
🐛 fix: update cssVar type to AntdToken in CreateStylesUtils interface

### DIFF
--- a/src/factories/createStyles/types.ts
+++ b/src/factories/createStyles/types.ts
@@ -1,4 +1,5 @@
 import type {
+  AntdToken,
   BaseReturnType,
   CommonStyleUtils,
   FullStylish,
@@ -16,7 +17,10 @@ export interface CreateStylesUtils extends CommonStyleUtils {
    * 包含 antd 的 token 和所有自定义 token
    */
   token: FullToken;
-  cssVar: FullToken;
+  /**
+   * 支持通过 cssVar 访问的 antd Token，[不包含自定义 Token](https://github.com/ant-design/antd-style/issues/199)
+   */
+  cssVar: AntdToken;
   stylish: FullStylish;
   /**
    * ThemeProvider 下当前的主题模式


### PR DESCRIPTION
close #199

### 解决方案

`cssVar` 暂不支持消费由 `<ThemeProvider />` 定义的 `customToken`。 在 TS 类型中先移除。CC @MadCcc 