### PR TITLE
refactor: split ThemeModeContext into multiple contexts

### DIFF
--- a/src/context/ThemeModeContext.test.ts
+++ b/src/context/ThemeModeContext.test.ts
@@ -2,25 +2,33 @@ import { renderHook } from '@testing-library/react';
 import { useContext } from 'react';
 import { vi } from 'vitest';
 
-import { ThemeModeContext } from './ThemeModeContext';
+import {
+  AppearanceContext,
+  BrowserPrefersContext,
+  ThemeActionContext,
+  ThemeModeValueContext,
+} from './ThemeModeContext';
 
 describe('ThemeModeContext', () => {
   it('should have default values', () => {
-    const { result } = renderHook(() => useContext(ThemeModeContext));
-    expect(result.current.appearance).toEqual('light');
-    expect(result.current.isDarkMode).toEqual(false);
-    expect(result.current.themeMode).toEqual('light');
-    expect(result.current.browserPrefers).toEqual('light');
-    expect(result.current.setAppearance).toBeDefined();
-    expect(result.current.setThemeMode).toBeDefined();
+    const { result: appearance } = renderHook(() => useContext(AppearanceContext));
+    const { result: themeMode } = renderHook(() => useContext(ThemeModeValueContext));
+    const { result: browserPrefers } = renderHook(() => useContext(BrowserPrefersContext));
+    const { result: actions } = renderHook(() => useContext(ThemeActionContext));
+
+    expect(appearance.current).toEqual('light');
+    expect(themeMode.current).toEqual('light');
+    expect(browserPrefers.current).toEqual('light');
+    expect(actions.current.setAppearance).toBeDefined();
+    expect(actions.current.setThemeMode).toBeDefined();
   });
 
   it('should return false when window is undefined', () => {
     const matchMedia = vi.fn();
     Object.defineProperty(window, 'matchMedia', { value: matchMedia });
 
-    const { result } = renderHook(() => useContext(ThemeModeContext));
-    expect(result.current.browserPrefers).toEqual('light');
+    const { result: browserPrefers } = renderHook(() => useContext(BrowserPrefersContext));
+    expect(browserPrefers.current).toEqual('light');
     expect(matchMedia).not.toHaveBeenCalled();
   });
 });

--- a/src/context/ThemeModeContext.ts
+++ b/src/context/ThemeModeContext.ts
@@ -1,13 +1,28 @@
 import { createContext } from 'react';
 
-import { ThemeContextState } from '@/types';
+import { BrowserPrefers, ThemeAppearance, ThemeMode } from '@/types';
 import { matchBrowserPrefers } from '@/utils/matchBrowserPrefers';
 
-export const ThemeModeContext = createContext<ThemeContextState>({
-  appearance: 'light',
-  setAppearance: () => {},
-  isDarkMode: false,
-  themeMode: 'light',
-  setThemeMode: () => {},
-  browserPrefers: matchBrowserPrefers('dark')?.matches ? 'dark' : 'light',
+// ---- Fine-grained State Contexts (primitives, reference-stable when value unchanged) ----
+
+export const AppearanceContext = createContext<ThemeAppearance>('light');
+
+export const ThemeModeValueContext = createContext<ThemeMode>('light');
+
+export const BrowserPrefersContext = createContext<BrowserPrefers>(
+  matchBrowserPrefers('dark')?.matches ? 'dark' : 'light',
+);
+
+// ---- Action Context (function refs, stable across renders) ----
+
+export interface ThemeActions {
+  setAppearance: (appearance: ThemeAppearance) => void;
+  setThemeMode: (themeMode: ThemeMode) => void;
+}
+
+const noop = () => {};
+
+export const ThemeActionContext = createContext<ThemeActions>({
+  setAppearance: noop,
+  setThemeMode: noop,
 });

--- a/src/factories/createThemeProvider/AntdProvider.tsx
+++ b/src/factories/createThemeProvider/AntdProvider.tsx
@@ -1,7 +1,7 @@
 import { ConfigProvider, message, Modal, notification, theme, ThemeConfig } from 'antd';
-import { memo, useEffect, useMemo, type FC } from 'react';
+import { memo, useContext, useEffect, useMemo, type FC } from 'react';
 
-import { useThemeMode } from '@/hooks';
+import { AppearanceContext } from '@/context';
 import type { ThemeProviderProps } from './type';
 
 type AntdProviderProps = Pick<
@@ -11,7 +11,8 @@ type AntdProviderProps = Pick<
 
 const AntdProvider: FC<AntdProviderProps> = memo(
   ({ children, theme: themeProp, prefixCls, getStaticInstance, staticInstanceConfig }) => {
-    const { appearance, isDarkMode } = useThemeMode();
+    const appearance = useContext(AppearanceContext);
+    const isDarkMode = appearance === 'dark';
 
     const [messageInstance, messageContextHolder] = message.useMessage(
       staticInstanceConfig?.message,

--- a/src/factories/createThemeProvider/ThemeSwitcher.test.tsx
+++ b/src/factories/createThemeProvider/ThemeSwitcher.test.tsx
@@ -1,16 +1,15 @@
 import { fireEvent, render } from '@testing-library/react';
 import { vi } from 'vitest';
 
-import { ThemeModeContext } from '@/context';
+import {
+  AppearanceContext,
+  BrowserPrefersContext,
+  ThemeActionContext,
+  ThemeModeValueContext,
+} from '@/context';
 import { useTheme } from '@/functions';
 import { useThemeMode } from '@/hooks';
-import { ThemeContextState } from '@/types';
 import ThemeSwitcher, { ThemeSwitcherProps } from './ThemeSwitcher';
-
-const mockUseTheme = {
-  appearance: 'light',
-  themeMode: 'light',
-} as ThemeContextState;
 
 const MockedChild = () => {
   const theme = useTheme();
@@ -36,12 +35,20 @@ const MockedChild = () => {
   );
 };
 
+const noop = () => {};
+
 const Component = (props: Partial<ThemeSwitcherProps>) => (
-  <ThemeModeContext.Provider value={mockUseTheme}>
-    <ThemeSwitcher {...props} useTheme={useTheme}>
-      <MockedChild />
-    </ThemeSwitcher>
-  </ThemeModeContext.Provider>
+  <ThemeModeValueContext.Provider value="light">
+    <AppearanceContext.Provider value="light">
+      <BrowserPrefersContext.Provider value="light">
+        <ThemeActionContext.Provider value={{ setThemeMode: noop, setAppearance: noop }}>
+          <ThemeSwitcher {...props} useTheme={useTheme}>
+            <MockedChild />
+          </ThemeSwitcher>
+        </ThemeActionContext.Provider>
+      </BrowserPrefersContext.Provider>
+    </AppearanceContext.Provider>
+  </ThemeModeValueContext.Provider>
 );
 
 describe('<ThemeSwitcher />', () => {

--- a/src/factories/createThemeProvider/ThemeSwitcher.tsx
+++ b/src/factories/createThemeProvider/ThemeSwitcher.tsx
@@ -1,7 +1,12 @@
 import { FC, memo, ReactNode, useLayoutEffect, useState } from 'react';
 import useMergeValue from 'use-merge-value';
 
-import { ThemeModeContext } from '@/context';
+import {
+  AppearanceContext,
+  BrowserPrefersContext,
+  ThemeActionContext,
+  ThemeModeValueContext,
+} from '@/context';
 import { BrowserPrefers, ThemeAppearance, ThemeMode, UseTheme } from '@/types';
 import { matchBrowserPrefers } from '@/utils/matchBrowserPrefers';
 import { safeStartTransition } from '@/utils/safeStartTransition';
@@ -120,29 +125,28 @@ const ThemeSwitcher: FC<ThemeSwitcherProps> = memo(
       matchBrowserPrefers('dark')?.matches ? 'dark' : 'light',
     );
 
+    const [actions] = useState(() => ({
+      setAppearance,
+      setThemeMode,
+    }));
+
     return (
-      <ThemeModeContext.Provider
-        value={{
-          themeMode,
-          setThemeMode,
-          appearance,
-          setAppearance,
-          isDarkMode: appearance === 'dark',
-          browserPrefers,
-        }}
-      >
-        {
-          // Wait until after client-side hydration to show
-          typeof window !== 'undefined' && (
-            <ThemeObserver
-              themeMode={themeMode}
-              setAppearance={setAppearance}
-              setBrowserPrefers={setBrowserPrefers}
-            />
-          )
-        }
-        {children}
-      </ThemeModeContext.Provider>
+      <ThemeModeValueContext.Provider value={themeMode}>
+        <AppearanceContext.Provider value={appearance}>
+          <BrowserPrefersContext.Provider value={browserPrefers}>
+            <ThemeActionContext.Provider value={actions}>
+              {typeof window !== 'undefined' && (
+                <ThemeObserver
+                  themeMode={themeMode}
+                  setAppearance={setAppearance}
+                  setBrowserPrefers={setBrowserPrefers}
+                />
+              )}
+              {children}
+            </ThemeActionContext.Provider>
+          </BrowserPrefersContext.Provider>
+        </AppearanceContext.Provider>
+      </ThemeModeValueContext.Provider>
     );
   },
 );

--- a/src/factories/createThemeProvider/TokenContainer.tsx
+++ b/src/factories/createThemeProvider/TokenContainer.tsx
@@ -1,7 +1,13 @@
-import { ReactElement, useMemo } from 'react';
+import { ReactElement, useContext, useMemo } from 'react';
 
+import {
+  AppearanceContext,
+  BrowserPrefersContext,
+  ThemeActionContext,
+  ThemeModeValueContext,
+} from '@/context';
 import { serializeCSS } from '@/core';
-import { useAntdTheme, useThemeMode } from '@/hooks';
+import { useAntdTheme } from '@/hooks';
 import { StyledThemeProvider, Theme } from '@/types';
 
 import type { ThemeProviderProps } from './type';
@@ -23,8 +29,12 @@ const TokenContainer: <T, S>(props: TokenContainerProps<T, S>) => ReactElement |
   prefixCls,
   StyledThemeProvider,
 }) => {
-  const themeState = useThemeMode();
-  const { appearance, isDarkMode } = themeState;
+  const appearance = useContext(AppearanceContext);
+  const isDarkMode = appearance === 'dark';
+  const themeMode = useContext(ThemeModeValueContext);
+  const browserPrefers = useContext(BrowserPrefersContext);
+  const { setAppearance, setThemeMode } = useContext(ThemeActionContext);
+
   const { stylish: antdStylish, ...token } = useAntdTheme();
 
   // 获取默认的自定义 token
@@ -65,13 +75,31 @@ const TokenContainer: <T, S>(props: TokenContainerProps<T, S>) => ReactElement |
     [customStylish, antdStylish],
   );
 
-  const theme: Theme = {
-    ...token,
-    ...(customToken as any),
-    stylish: stylish as any,
-    ...themeState,
-    prefixCls,
-  };
+  const theme = useMemo<Theme>(
+    () => ({
+      ...token,
+      ...(customToken as any),
+      stylish: stylish as any,
+      appearance,
+      isDarkMode,
+      themeMode,
+      setThemeMode,
+      setAppearance,
+      browserPrefers,
+      prefixCls,
+    }),
+    [
+      token,
+      customToken,
+      stylish,
+      appearance,
+      themeMode,
+      setThemeMode,
+      setAppearance,
+      browserPrefers,
+      prefixCls,
+    ],
+  );
 
   return <StyledThemeProvider theme={theme}>{children}</StyledThemeProvider>;
 };

--- a/src/factories/createThemeProvider/index.tsx
+++ b/src/factories/createThemeProvider/index.tsx
@@ -1,4 +1,4 @@
-import { Context, FC, memo, useContext } from 'react';
+import { Context, FC, memo, useContext, useMemo } from 'react';
 
 import { DEFAULT_THEME_CONTEXT, DEFAULT_THEME_PROVIDER } from '@/functions/setupStyled';
 import { StyleEngine, StyledConfig, UseTheme } from '@/types';
@@ -77,14 +77,20 @@ export const createThemeProvider = (
 
       const prefixCls = outPrefixCls || defaultPrefixCls;
 
+      const resolvedStyledThemeContext =
+        styled?.ThemeContext || StyledThemeContext || DEFAULT_THEME_CONTEXT;
+
+      const styleEngineValue = useMemo(
+        () => ({
+          prefixCls,
+          StyledThemeContext: resolvedStyledThemeContext,
+          CustomThemeContext,
+        }),
+        [prefixCls, resolvedStyledThemeContext, CustomThemeContext],
+      );
+
       return (
-        <StyleEngineContext.Provider
-          value={{
-            prefixCls: prefixCls,
-            StyledThemeContext: styled?.ThemeContext || StyledThemeContext || DEFAULT_THEME_CONTEXT,
-            CustomThemeContext,
-          }}
-        >
+        <StyleEngineContext.Provider value={styleEngineValue}>
           <ThemeSwitcher
             themeMode={themeMode}
             defaultThemeMode={defaultThemeMode}

--- a/src/factories/createUseTheme.ts
+++ b/src/factories/createUseTheme.ts
@@ -1,10 +1,17 @@
 import { StyleEngine, Theme } from '@/types';
 import { Context, useContext, useMemo } from 'react';
 
+import {
+  AppearanceContext,
+  BrowserPrefersContext,
+  ThemeActionContext,
+  ThemeModeValueContext,
+} from '@/context';
 import { DEFAULT_THEME_CONTEXT } from '@/functions/setupStyled';
 import { useAntdTheme } from '@/hooks/useAntdTheme';
-import { useThemeMode } from '@/hooks/useThemeMode';
 import { ConfigProvider } from 'antd';
+
+const EMPTY_THEME = {} as const;
 
 interface CreateUseThemeOptions {
   StyleEngineContext: Context<StyleEngine>;
@@ -12,34 +19,55 @@ interface CreateUseThemeOptions {
 
 export const createUseTheme = (options: CreateUseThemeOptions) => (): Theme => {
   const { StyleEngineContext } = options;
-  const {
-    StyledThemeContext,
-    CustomThemeContext,
-    prefixCls: outPrefixCls,
-  } = useContext(StyleEngineContext);
+  const styleEngine = useContext(StyleEngineContext);
+  const { StyledThemeContext, CustomThemeContext, prefixCls: outPrefixCls } = styleEngine;
 
   const antdTheme = useAntdTheme();
-  const themeState = useThemeMode();
+
+  const appearance = useContext(AppearanceContext);
+  const themeMode = useContext(ThemeModeValueContext);
+  const browserPrefers = useContext(BrowserPrefersContext);
+  const actions = useContext(ThemeActionContext);
+  const { setAppearance, setThemeMode } = actions;
 
   const defaultCustomTheme = useContext(CustomThemeContext);
-  const styledTheme = useContext(StyledThemeContext ?? DEFAULT_THEME_CONTEXT) || {};
+  const styledTheme = useContext(StyledThemeContext ?? DEFAULT_THEME_CONTEXT) || EMPTY_THEME;
 
-  const { iconPrefixCls, getPrefixCls } = useContext(ConfigProvider.ConfigContext);
+  const configCtx = useContext(ConfigProvider.ConfigContext);
+  const { iconPrefixCls, getPrefixCls } = configCtx;
 
   const antdPrefixCls = getPrefixCls();
-  // 只有当用户在 createInstance 中传入与 ant 不一样的 prefixCls 时，才会使用用户的 prefixCls
-  // 否则其他情况下都优先使用 antd 的 prefixCls
   const prefixCls = outPrefixCls && outPrefixCls !== 'ant' ? outPrefixCls : antdPrefixCls;
 
   const initTheme = useMemo<Theme>(
     () => ({
       ...antdTheme,
-      ...themeState,
+      appearance,
+      isDarkMode: appearance === 'dark',
+      themeMode,
+      setThemeMode,
+      setAppearance,
+      browserPrefers,
       ...defaultCustomTheme,
       prefixCls,
       iconPrefixCls,
     }),
-    [antdTheme, themeState, defaultCustomTheme, prefixCls, iconPrefixCls],
+    [
+      antdTheme,
+      appearance,
+      themeMode,
+      browserPrefers,
+      setThemeMode,
+      setAppearance,
+      defaultCustomTheme,
+      prefixCls,
+      iconPrefixCls,
+    ],
+  );
+
+  const styledThemeResult = useMemo<Theme>(
+    () => ({ ...styledTheme, prefixCls, iconPrefixCls } as Theme),
+    [styledTheme, prefixCls, iconPrefixCls],
   );
 
   //  如果是个空值，说明没有套 Provider，返回 antdTheme 的默认值
@@ -47,5 +75,5 @@ export const createUseTheme = (options: CreateUseThemeOptions) => (): Theme => {
     return initTheme;
   }
 
-  return { ...styledTheme, prefixCls, iconPrefixCls } as Theme;
+  return styledThemeResult;
 };

--- a/src/hooks/useAntdStylish.ts
+++ b/src/hooks/useAntdStylish.ts
@@ -1,16 +1,17 @@
-import { useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 
+import { AppearanceContext } from '@/context';
 import { serializeCSS } from '@/core';
 import { createAntdStylish } from '@/stylish/button';
 import { AntdStylish } from '@/types';
 
 import { convertStylishToString } from '@/utils/convertStylish';
 import { useAntdToken } from './useAntdToken';
-import { useThemeMode } from './useThemeMode';
 
 export const useAntdStylish = (): AntdStylish => {
   const token = useAntdToken();
-  const { appearance, isDarkMode } = useThemeMode();
+  const appearance = useContext(AppearanceContext);
+  const isDarkMode = appearance === 'dark';
 
   return useMemo(
     () =>

--- a/src/hooks/useThemeMode.ts
+++ b/src/hooks/useThemeMode.ts
@@ -1,6 +1,25 @@
 import { useContext } from 'react';
 
-import { ThemeModeContext } from '@/context';
+import {
+  AppearanceContext,
+  BrowserPrefersContext,
+  ThemeActionContext,
+  ThemeModeValueContext,
+} from '@/context';
 import { ThemeContextState } from '@/types';
 
-export const useThemeMode = (): ThemeContextState => useContext(ThemeModeContext);
+export const useThemeMode = (): ThemeContextState => {
+  const appearance = useContext(AppearanceContext);
+  const themeMode = useContext(ThemeModeValueContext);
+  const browserPrefers = useContext(BrowserPrefersContext);
+  const { setAppearance, setThemeMode } = useContext(ThemeActionContext);
+
+  return {
+    appearance,
+    isDarkMode: appearance === 'dark',
+    themeMode,
+    setThemeMode,
+    setAppearance,
+    browserPrefers,
+  };
+};


### PR DESCRIPTION
Split ThemeModeContext into separate contexts for better state management:
- AppearanceContext
- ThemeModeValueContext  
- BrowserPrefersContext
- ThemeActionContext

This improves component isolation and state management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 `getAntdToken()` 函数，支持在不依赖 React 的情况下获取 Ant Design 设计令牌。
  * 增强 `extractStaticStyle()` 支持 `injectTokenStyle` 选项以注入 Ant Design 令牌 CSS 变量。

* **重构**
  * 重构主题上下文架构以减少不必要的重新渲染。

* **测试**
  * 新增样式创建性能基准测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->