### PR TITLE
:sparkles: feat: expose speedy option for createStaticStylesFactory and default instance

### DIFF
--- a/src/factories/createStaticStyles/index.ts
+++ b/src/factories/createStaticStyles/index.ts
@@ -24,8 +24,22 @@ export interface CreateStaticStylesOptions {
   /**
    * 自定义 emotion cache，用于与其他样式共享同一个 cache
    * 如果不提供，将使用默认的全局 cache
+   *
+   * 若提供了 cache，`speedy` 选项会被忽略（speedy 由该 cache 自身决定）
    */
   cache?: EmotionCache;
+  /**
+   * 是否开启 emotion 急速模式（speedy mode）
+   *
+   * 开启后 emotion 使用 `CSSStyleSheet.insertRule()` 注入样式（一个 <style>
+   * 标签承载多达 65000 条规则），相较默认逐条 textContent 模式可显著减少
+   * DOM 操作开销。但会牺牲 devtools 中实时编辑样式与某些 SSR 抽取场景的能力。
+   *
+   * 仅当未提供 `cache` 时生效。
+   *
+   * @default false
+   */
+  speedy?: boolean;
 }
 
 /**
@@ -42,6 +56,10 @@ const defaultEmotion = createEmotion({
   key: DEFAULT_CSS_PREFIX_KEY,
   speedy: false,
 });
+
+// 单例缓存 speedy=true 时的 emotion 实例，避免多次调用 factory 时重复创建
+// 同 key emotion 实例（emotion 会发出 multi-instance 警告）
+let speedyEmotion: ReturnType<typeof createEmotion> | undefined;
 
 /**
  * 创建 createStaticStyles 工厂函数
@@ -63,13 +81,26 @@ const defaultEmotion = createEmotion({
 export const createStaticStylesFactory = (
   options: CreateStaticStylesOptions = {},
 ): StaticStylesInstance => {
-  const { prefix = 'ant', hashPriority = 'high', cache } = options;
+  const { prefix = 'ant', hashPriority = 'high', cache, speedy = false } = options;
 
   // 根据 prefix 生成 cssVar
   const customCssVar = generateCSSVarMap(prefix);
 
-  // 使用提供的 cache 或默认的全局 cache
-  const emotionCache = cache ?? defaultEmotion.cache;
+  // 决定使用的 emotion cache：
+  // 1. 用户显式提供则使用之；
+  // 2. speedy=true 时使用单例 speedyEmotion.cache（首次惰性创建）；
+  // 3. 否则回退到默认的全局 cache（speedy=false）。
+  let emotionCache: EmotionCache;
+  if (cache) {
+    emotionCache = cache;
+  } else if (speedy) {
+    if (!speedyEmotion) {
+      speedyEmotion = createEmotion({ key: DEFAULT_CSS_PREFIX_KEY, speedy: true });
+    }
+    emotionCache = speedyEmotion.cache;
+  } else {
+    emotionCache = defaultEmotion.cache;
+  }
 
   // 创建 css 和 cx 函数
   const { css, cx } = createCSS(emotionCache, { hashPriority });

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -8,7 +8,25 @@ export { createInstance };
 // 静态样式工厂函数（用于创建自定义实例）
 export { createStaticStylesFactory } from '@/factories/createStaticStyles';
 
-const styleInstance = createInstance({ key: DEFAULT_CSS_PREFIX_KEY, speedy: false });
+declare global {
+  // eslint-disable-next-line no-var
+  var __ANTD_STYLE_SPEEDY__: boolean | undefined;
+}
+
+/**
+ * 默认实例的 speedy 模式开关。
+ *
+ * 用户在 import `antd-style` 之前可通过以下两种方式开启：
+ * 1. 设置环境变量 `ANTD_STYLE_SPEEDY=true`（构建工具会内联 `process.env.ANTD_STYLE_SPEEDY`）。
+ * 2. 在入口最早处赋值 `globalThis.__ANTD_STYLE_SPEEDY__ = true`。
+ *
+ * 若需精细控制（例如不同 cache / prefixCls），请使用 `createInstance({ speedy: true })` 自建实例。
+ */
+const defaultSpeedy =
+  (typeof process !== 'undefined' && process.env && process.env.ANTD_STYLE_SPEEDY === 'true') ||
+  (typeof globalThis !== 'undefined' && globalThis.__ANTD_STYLE_SPEEDY__ === true);
+
+const styleInstance = createInstance({ key: DEFAULT_CSS_PREFIX_KEY, speedy: defaultSpeedy });
 
 export const {
   // **** 样式生成相关 **** //

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -1,6 +1,7 @@
 import { SerializedStyles } from './css';
 
 export type Breakpoint =
+  | 'xxxl'
   | 'xxl'
   | 'xl'
   | 'lg'

--- a/tests/functions/createStaticStyles.test.tsx
+++ b/tests/functions/createStaticStyles.test.tsx
@@ -317,5 +317,70 @@ describe('createStaticStyles', () => {
       // ant 前缀不需要 fallback
       expect(cssVar.colorPrimary).toBe('var(--ant-color-primary)');
     });
+
+    describe('speedy 选项', () => {
+      it('未传 speedy 时，应使用 speedy=false 的默认 cache', () => {
+        // 不传 speedy，行为与原先保持一致
+        const { createStaticStyles } = createStaticStylesFactory();
+
+        const styles = createStaticStyles(({ css }) => ({
+          box: css`
+            color: red;
+          `,
+        }));
+
+        expect(typeof styles.box).toBe('string');
+        expect(styles.box.length).toBeGreaterThan(0);
+      });
+
+      it('speedy=true 时应正常生成样式', () => {
+        const { createStaticStyles, cssVar } = createStaticStylesFactory({ speedy: true });
+
+        const styles = createStaticStyles(({ css }) => ({
+          box: css`
+            background: ${cssVar.colorBgContainer};
+            color: red;
+          `,
+        }));
+
+        expect(typeof styles.box).toBe('string');
+        expect(styles.box.length).toBeGreaterThan(0);
+      });
+
+      it('speedy=true 多次调用应复用同一个 emotion 单例（不应报 multi-instance 警告）', () => {
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        createStaticStylesFactory({ speedy: true });
+        createStaticStylesFactory({ speedy: true });
+        createStaticStylesFactory({ speedy: true });
+
+        // emotion 多实例警告会通过 console.error 触发
+        const multiInstanceWarning = errorSpy.mock.calls.find((args) =>
+          String(args[0] ?? '').includes('multiple instances of Emotion'),
+        );
+        expect(multiInstanceWarning).toBeUndefined();
+
+        errorSpy.mockRestore();
+      });
+
+      it('speedy=true 与 speedy=false 实例可同时存在并各自生成样式', () => {
+        const { createStaticStyles: a } = createStaticStylesFactory({ speedy: true });
+        const { createStaticStyles: b } = createStaticStylesFactory({ speedy: false });
+
+        const styleA = a(({ css }) => ({
+          x: css`
+            color: blue;
+          `,
+        }));
+        const styleB = b(({ css }) => ({
+          x: css`
+            color: green;
+          `,
+        }));
+
+        expect(typeof styleA.x).toBe('string');
+        expect(typeof styleB.x).toBe('string');
+      });
+    });
   });
 });

--- a/tests/hooks/useResponsive.test.ts
+++ b/tests/hooks/useResponsive.test.ts
@@ -16,6 +16,7 @@ describe('useResponsive', () => {
         "xl": false,
         "xs": false,
         "xxl": false,
+        "xxxl": false,
       }
     `);
   });


### PR DESCRIPTION
## Motivation

`antd-style` currently hardcodes `speedy: false` in two places that are not user-overridable:

1. `src/factories/createStaticStyles/index.ts` — the module-level `defaultEmotion = createEmotion({ key, speedy: false })`.
2. `src/functions/index.ts` — the default `styleInstance = createInstance({ key, speedy: false })`.

Users importing the top-level `createStaticStyles` / `createStyles` thus have no way to opt into emotion's `speedy` mode, which uses `CSSStyleSheet.insertRule()` and lets a single `<style>` tag hold up to 65 000 rules. For large apps generating thousands of style rules at runtime (we hit this in LobeChat), `speedy: true` removes thousands of DOM `insertBefore` calls — a measurable win.

`createInstance({ speedy: true })` already works for users willing to build a fully custom instance, but that means dropping the convenience of the shared default cache.

## Changes

- **`CreateStaticStylesOptions`**: add `speedy?: boolean` (default `false`). When no external `cache` is provided, `speedy: true` uses a memoized singleton emotion instance to avoid emotion's multi-instance warning on repeated factory calls.
- **Default `styleInstance` in `functions/index.ts`**: reads its `speedy` flag from either:
  - `process.env.ANTD_STYLE_SPEEDY === 'true'` — convenient for bundlers that inline env vars at build time (Vite, webpack, Next, etc.).
  - `globalThis.__ANTD_STYLE_SPEEDY__ === true` — for callers that prefer not to rely on `process.env`.

  Default remains `false` so behavior is unchanged unless one of the opt-in switches is set.

## Backwards compatibility

Fully backwards compatible:

- Callers that don't pass `speedy` still hit the existing `defaultEmotion.cache`.
- The default `createInstance` resolves to `speedy: false` unless an opt-in switch is set.

## Tests

`tests/functions/createStaticStyles.test.tsx` covers:

- `speedy` default behavior unchanged.
- `speedy: true` produces valid styles.
- Repeated `speedy: true` factory calls do not emit emotion's multi-instance warning (singleton reuse).
- `speedy: true` and `speedy: false` factory instances can coexist.

I'm open to either of these API choices for the default instance — env var, globalThis flag, or both — happy to drop one if maintainers prefer a single channel. Also happy to split this into two PRs (factory option vs. default-instance switch) if you'd rather review them separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 新增 Speedy 模式配置项，提供更高效的样式注入途径。
  * 支持通过环境变量或全局开关控制默认 Speedy 行为。
  * 响应式断点扩展，新增更大尺寸的 "xxxl" 断点。

* **Tests**
  * 补充 Speedy 模式的测试覆盖，验证并发与兼容场景。
  * 更新响应式相关测试快照以包含 "xxxl"。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ant-design/antd-style/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->