### PR TITLE
🚀 feat: export staticStylesCache for build tooling & SSR extraction

### DIFF
--- a/src/factories/createStaticStyles/index.ts
+++ b/src/factories/createStaticStyles/index.ts
@@ -44,6 +44,15 @@ const defaultEmotion = createEmotion({
 });
 
 /**
+ * createStaticStylesFactory 默认实例使用的 emotion cache
+ *
+ * 供构建工具（如 vite-plugin-antd-style 静态编译插件）与 SSR 样式抽取读取：
+ * 未显式传入 cache 的工厂实例产生的样式记录在这里，而非全局 CacheManager 中，
+ * 此前对外完全不可达。
+ */
+export const staticStylesCache = defaultEmotion.cache;
+
+/**
  * 创建 createStaticStyles 工厂函数
  *
  * 用于创建带有自定义 prefix 的 createStaticStyles 实例

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -6,7 +6,7 @@ export { setupStyled } from './setupStyled';
 export { createInstance };
 
 // 静态样式工厂函数（用于创建自定义实例）
-export { createStaticStylesFactory } from '@/factories/createStaticStyles';
+export { createStaticStylesFactory, staticStylesCache } from '@/factories/createStaticStyles';
 
 const styleInstance = createInstance({ key: DEFAULT_CSS_PREFIX_KEY, speedy: false });
 

--- a/tests/__snapshots__/export.test.tsx.snap
+++ b/tests/__snapshots__/export.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`export > should work 1`] = `
   "setupStyled",
   "createInstance",
   "createStaticStylesFactory",
+  "staticStylesCache",
   "createStyles",
   "createGlobalStyle",
   "createStylish",

--- a/tests/functions/createStaticStyles.test.tsx
+++ b/tests/functions/createStaticStyles.test.tsx
@@ -1,5 +1,12 @@
 import { render } from '@testing-library/react';
-import { createStaticStyles, createStaticStylesFactory, cssVar, cx, responsive } from 'antd-style';
+import {
+  createStaticStyles,
+  createStaticStylesFactory,
+  cssVar,
+  cx,
+  responsive,
+  staticStylesCache,
+} from 'antd-style';
 
 describe('createStaticStyles', () => {
   describe('基础功能', () => {
@@ -316,6 +323,26 @@ describe('createStaticStyles', () => {
 
       // ant 前缀不需要 fallback
       expect(cssVar.colorPrimary).toBe('var(--ant-color-primary)');
+    });
+  });
+
+  describe('staticStylesCache', () => {
+    it('未显式传入 cache 的工厂实例，样式应记录在 staticStylesCache 中', () => {
+      const { createStaticStyles } = createStaticStylesFactory({ prefix: 'cache-probe' });
+
+      const styles = createStaticStyles(({ css }) => ({
+        probe: css`
+          outline-offset: 7px;
+        `,
+      }));
+
+      // className 形如 `${cache.key}-${hash}`，剥掉 key 前缀得到 hash
+      const hash = styles.probe.slice(staticStylesCache.key.length + 1);
+
+      // 构建工具与 SSR 抽取依赖该 cache 收集工厂实例的样式
+      expect(styles.probe.startsWith(`${staticStylesCache.key}-`)).toBe(true);
+      expect(staticStylesCache.inserted[hash]).toBeDefined();
+      expect(staticStylesCache.registered[styles.probe]).toContain('outline-offset: 7px');
     });
   });
 });

--- a/tests/hooks/useResponsive.test.ts
+++ b/tests/hooks/useResponsive.test.ts
@@ -16,6 +16,7 @@ describe('useResponsive', () => {
         "xl": false,
         "xs": false,
         "xxl": false,
+        "xxxl": false,
       }
     `);
   });


### PR DESCRIPTION
## 背景

antd-style 静态编译插件已抽到独立仓库快速验证：[arvinxx/vite-plugin-antd-style](https://github.com/arvinxx/vite-plugin-antd-style)（构建期把 `createStaticStyles` 编译为 className 字面量 + CSS 文件，70 用例等价性验收合同全绿）。

本 PR 裁剪为 antd-style 侧需要合入的**最小改动**。

## 改动

**导出 `staticStylesCache`**（`createStaticStylesFactory` 默认实例使用的 emotion cache）：

- 未显式传入 `cache` 的工厂实例，其样式记录在该 cache 中，而非全局 `CacheManager`——此前对外完全不可达；
- 构建工具（静态编译插件收集工厂实例的样式）与 SSR 样式抽取（`extractStaticStyle` 目前只读 CacheManager，同样漏掉这部分）都需要这个访问点；
- 附带一个针对性测试：工厂实例的样式确实落在 `staticStylesCache` 中。

**附带修复**：`useResponsive` 的 inline snapshot 过期——仓库无 lockfile，`antd: ^6.0.0` 漂移到 6.5 后新增 `xxxl` 断点，master 全新安装即失败。

## 验证

101 用例（98 过 / 3 既有跳过）、type-check、lint、father build 全部通过。

发布后，插件即可启用 `createStaticStylesFactory` 自定义 prefix 实例的静态编译支持（当前对该场景自动回退运行时）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 支持访问默认样式缓存，便于静态样式抽取和服务器端渲染场景使用。
* **Tests**
  * 更新了响应式钩子测试快照，覆盖新增字段。
  * 补充了静态样式缓存相关测试，验证默认样式会正确写入缓存。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->